### PR TITLE
Improved platform independence

### DIFF
--- a/lib/get-package.js
+++ b/lib/get-package.js
@@ -30,7 +30,7 @@ function getPackage (pack) {
   } else if (pack == null) {
     // try to read it
     try {
-      return JSON.parse(fs.readFileSync(path.join(rootFolder + '/package.json'), 'utf-8'))
+      return JSON.parse(fs.readFileSync(path.join(rootFolder, 'package.json'), 'utf-8'))
     } catch (e) {
       throw new Error('Could not find package.json')
     }


### PR DESCRIPTION
Removed path separator to make it join in a platform independent way.

This is broken when used within cygwin on Windows.